### PR TITLE
sysdep.h: fix for macOS

### DIFF
--- a/saclib/include/sysdep.h
+++ b/saclib/include/sysdep.h
@@ -1,9 +1,27 @@
-#ifndef _LITTLE_ENDIAN_
-#define _LITTLE_ENDIAN_
+#ifdef __POWERPC__
+# ifndef _BIG_ENDIAN_
+#  define _BIG_ENDIAN_
+# endif
+# undef _LITTLE_ENDIAN_
+# ifdef __ppc64__
+#  define __WORDSIZE 64
+# else
+#  define __WORDSIZE 32
+# endif
+# ifdef __APPLE__
+#  define _MAC_OSX_
+# endif
+#else
+# ifndef _LITTLE_ENDIAN_
+#  define _LITTLE_ENDIAN_
+# endif
+# undef _BIG_ENDIAN_
+# ifndef _WIN32
+#  ifdef __APPLE__
+#   define _MAC_OSX_
+#  else
+#   define _X86_LINUX_
+#  endif
+#  define __WORDSIZE 64
+# endif
 #endif
-#undef _BIG_ENDIAN_
-#ifndef _WIN32
-#define _X86_LINUX_
-#endif
-#define __WORDSIZE 64
-


### PR DESCRIPTION
With this patch, `ppc` build on macOS is fixed:
```
--->  Testing qepcad
Executing:  cd "/opt/local/var/macports/build/_opt_PPCRosettaPorts_math_qepcad/qepcad/work/build" && ctest test 
Test project /opt/local/var/macports/build/_opt_PPCRosettaPorts_math_qepcad/qepcad/work/build
    Start 1: test_problem1
1/8 Test #1: test_problem1 ....................   Passed    0.71 sec
    Start 2: test_problem2
2/8 Test #2: test_problem2 ....................   Passed    0.74 sec
    Start 3: test_problem3
3/8 Test #3: test_problem3 ....................   Passed    0.70 sec
    Start 4: test_problem4
4/8 Test #4: test_problem4 ....................   Passed    0.69 sec
    Start 5: test_problem5
5/8 Test #5: test_problem5 ....................   Passed    0.83 sec
    Start 6: test_problem6
6/8 Test #6: test_problem6 ....................   Passed    1.16 sec
    Start 7: test_problem7
7/8 Test #7: test_problem7 ....................   Passed    0.72 sec
    Start 8: issue_3
8/8 Test #8: issue_3 ..........................   Passed    2.66 sec

100% tests passed, 0 tests failed out of 8
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/PetterS/qepcad/6)
<!-- Reviewable:end -->
