### PR TITLE
Fix build with gcc14

### DIFF
--- a/saclib/include/sacproto.h
+++ b/saclib/include/sacproto.h
@@ -232,6 +232,7 @@ extern void FIRST5	P__((Word L, Word *a1_, Word *a2_, Word *a3_, Word *a4_, Word
 extern void FIRST6	P__((Word L, Word *a1_, Word *a2_, Word *a3_, Word *a4_, Word *a5_, Word *a6_));
 extern Word FLBRN	P__((BDigit *F));
 extern Word FOURTH	P__((Word L));
+extern void FPCATCH     P__((void));
 extern Word FPCHECK	P__((void));
 extern void FPROD	P__((Word *A, Word *B, BDigit d, Word *C));
 extern void FPROD1	P__((Word *A, Word *B, BDigit d, Word *C));


### PR DESCRIPTION
## Summary
- declare `FPCATCH` in saclib headers

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_6843d19ac934832f9744259fd88f2d78

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/PetterS/qepcad/12)
<!-- Reviewable:end -->
